### PR TITLE
fix: Update event parameter names

### DIFF
--- a/mkdocs_your_plugin/plugin.py
+++ b/mkdocs_your_plugin/plugin.py
@@ -10,7 +10,7 @@ from mkdocs.plugins import BasePlugin
 class YourPlugin(BasePlugin):
 
     config_scheme = (
-        ('param', config_options.Type(mkdocs_utils.string_types, default='')),
+        ('param', config_options.Type(str, default='')),
     )
 
     def __init__(self):
@@ -29,7 +29,7 @@ class YourPlugin(BasePlugin):
     def on_nav(self, nav, config, files):
         return nav
 
-    def on_env(self, env, config, site_nav):
+    def on_env(self, env, config, files):
         return env
     
     def on_config(self, config):
@@ -47,16 +47,16 @@ class YourPlugin(BasePlugin):
     def on_post_template(self, output_content, template_name, config):
         return output_content
     
-    def on_pre_page(self, page, config, site_nav):
+    def on_pre_page(self, page, config, files):
         return page
 
     def on_page_read_source(self, page, config):
         return ""
 
-    def on_page_markdown(self, markdown, page, config, site_nav):
+    def on_page_markdown(self, markdown, page, config, files):
         return markdown
 
-    def on_page_content(self, html, page, config, site_nav):
+    def on_page_content(self, html, page, config, files):
         return html
 
     def on_page_context(self, context, page, config, nav):


### PR DESCRIPTION
Hi @byrnereese, I'm using your MkDocs plugin template to bootstrap a [new plugin](https://github.com/prcr/mkdocs-meta-descriptions-plugin) that I'm creating and found that a few event parameter names seemed to be outdated, causing the `mkdocs build` command to fail with errors. This pull request makes the necessary updates so that the build is successful.